### PR TITLE
feat(IT-73): refactoring gandleSubmith and apiTypes

### DIFF
--- a/src/shared/types/api/baseApi.types.ts
+++ b/src/shared/types/api/baseApi.types.ts
@@ -24,15 +24,6 @@ export type userLogin = {
   password: string
 }
 
-export type registrationError = {
-  errorsMessages: [
-    {
-      field: string
-      message: string
-    },
-  ]
-}
-
 export type registrationSuccess = {
   accessToken: string
 }
@@ -40,4 +31,41 @@ export type registrationSuccess = {
 export type userPasswordRecovery = {
   email: string
   recaptchaToken: string
+}
+
+// --------------------
+// Errors
+// --------------------
+
+export type registrationError = {
+  errorsMessages: {
+    field: string
+    message: string
+  }[]
+}
+
+export type FieldError = {
+  field: string
+  message: string
+}
+
+export type BadRequestError = {
+  status: 400
+  data: {
+    errorsMessages: FieldError[]
+  }
+}
+
+export type UnauthorizedError = {
+  status: 401
+  data: {
+    message: string
+  }
+}
+
+export type NotFoundError = {
+  status: 404
+  data: {
+    message: string
+  }
 }


### PR DESCRIPTION
Added error handling for the password recovery form (ForgotPasswordForm):
400 (Bad Request) errors are handled with messages from errorsMessages.
401 (Unauthorized) and 404 (Not Found) errors are handled with custom messages.
Added and clarified error types in baseApi.types.ts:
BadRequestError, UnauthorizedError, NotFoundError
General FieldError type for describing the error structure.
